### PR TITLE
Different issue categorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,18 @@ Issue tracker for Unvanquished gameplay related feedback, problems and new ideas
 To have a fruitful discussion, every issue here **must** fall clearly into one
 of the following categories:
 
-## Experience & Feedback
+## Experience
 
 You can talk freely about how you felt during a game of Unvanquished or when
 playing in general. You can let us know what was frustrating or enjoyable to
 you but please make it clear that these are your feelings and refrain from
 including any proposals or ideas in such an issue.
 
-Unlike `Problems`, `Experience & Feedback` are only for documentation purpose and not answered with solution proposals but it
+Unlike `Problems`, `Experience` are only for documentation purpose and not answered with solution proposals but it
 can help developers and players to come up with or agree with opinions about
 the current state of the game. 
 
-`Experience & Feedback` issues are closed 60 days after last activity. 
+`Experience` issues are closed 90 days after last activity. 
 
 **Example:** *When I play as a Dretch late in the match, I feel like I am stuck
 and can hardly evolve again.*
@@ -24,7 +24,7 @@ and can hardly evolve again.*
 ## Problem
 
 You can voice the opinion about **one** distinct aspect of the game is badly
-balanced or flawed by design. Unlike with `Experience & Feedback`, please try to be objective
+balanced or flawed by design. Unlike with `Experience`, please try to be objective
 and do not base your contribution only on your personal experience (which we
 cannot refute) but on arguments that we can agree with or reject. Please do not
 include proposals or ideas in such an issue as we want to discuss your opinion
@@ -35,18 +35,18 @@ that are too broadly scoped to lead to agreement, so be as specific as you can.
 
 **Example:** *The Barricade can be circumvented too easily with wall jumps.*
 
-## Idea, that solves a problem
+## Idea that solves a problem (Proposal)
 
 You may propose a change addressing **at least one problem issue**, which you must
-cite within your issue. If at least one of the cited problems was accepted we will only discuss your idea, not the problem,
-and may accept it for implementation and testing if we feel that it poses a
+cite within your issue. We will only discuss your idea, not the problem,
+and may accept it for implementation and testing if at least one of the cited problems was accepted and we feel that your idea poses a
 well rounded solution. Discussing alternative ideas within such an issue is
 not allowed but others may suggest alterations or variants and you may adjust
 your initial idea based on those. We will use the same flags as for
 opinions to keep track of good ideas even if we can't implement them
 immediately.
 
-If none of the cited problems are accepted the idea will be closed after 30 days.
+If none of the cited problems are agreed upon the idea will be closed after 30 days.
 
 **Example:** *Make the Barricade slow and hurt humans walking on top of it.*
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,30 @@
 # Gameplay
 
-Issue tracker for Unvanquished gameplay related feedback, opinions, proposals
-and new ideas.
+Issue tracker for Unvanquished gameplay related feedback, problems and new ideas.
 
 To have a fruitful discussion, every issue here **must** fall clearly into one
 of the following categories:
 
-## Feedback
+## Experience & Feedback
 
 You can talk freely about how you felt during a game of Unvanquished or when
 playing in general. You can let us know what was frustrating or enjoyable to
 you but please make it clear that these are your feelings and refrain from
-including any opinions, proposals or ideas in such an issue. This way we can
-just accept your feelings as a fact and are free to pursue any number of
-solutions or improvements in another issue. If your feedback suggests that a
-particular thing needs to change in a particular way, we will close it.
+including any proposals or ideas in such an issue.
 
-Unlike opinions, feedback may not be answered with solution proposals but it
+Unlike `Problems`, `Experience & Feedback` are only for documentation purpose and not answered with solution proposals but it
 can help developers and players to come up with or agree with opinions about
-the current state of the game. Because it is inherently true and cannot be
-rejected, pure feedback can be very helpful and influencial in the long run.
+the current state of the game. 
+
+`Experience & Feedback` issues are closed 60 days after last activity. 
 
 **Example:** *When I play as a Dretch late in the match, I feel like I am stuck
 and can hardly evolve again.*
 
-## Opinion
+## Problem
 
-You can voice the opinion that **one** distinct aspect of the game is badly
-balanced or flawed by design. Unlike with feedback, please try to be objective
+You can voice the opinion about **one** distinct aspect of the game is badly
+balanced or flawed by design. Unlike with `Experience & Feedback`, please try to be objective
 and do not base your contribution only on your personal experience (which we
 cannot refute) but on arguments that we can agree with or reject. Please do not
 include proposals or ideas in such an issue as we want to discuss your opinion
@@ -38,21 +35,18 @@ that are too broadly scoped to lead to agreement, so be as specific as you can.
 
 **Example:** *The Barricade can be circumvented too easily with wall jumps.*
 
-## Proposal
+## Idea, that solves a problem
 
-You may propose a change addressing **an agreed upon opinion**, which you must
-cite within your issue. We will only discuss your proposal, not the opinion,
+You may propose a change addressing **at least one problem issue**, which you must
+cite within your issue. If at least one of the cited problems was accepted we will only discuss your idea, not the problem,
 and may accept it for implementation and testing if we feel that it poses a
-well rounded solution. Discussing alternative proposals within such an issue is
+well rounded solution. Discussing alternative ideas within such an issue is
 not allowed but others may suggest alterations or variants and you may adjust
-your initial proposal based on those. We will use the same flags as for
-opinions to keep track of good proposals even if we can't implement them
+your initial idea based on those. We will use the same flags as for
+opinions to keep track of good ideas even if we can't implement them
 immediately.
 
-We understand that it can be frustrating to have a pair of opinion and proposal
-at the ready and not being allowed to discuss them in concert but this
-limitation is important for us to keep track of things and allow multiple
-proposals to compete, without anyone questioning their intention.
+If none of the cited problems are accepted the idea will be closed after 30 days.
 
 **Example:** *Make the Barricade slow and hurt humans walking on top of it.*
 
@@ -65,10 +59,6 @@ advertise your idea as fixing a problem within the first post that opens the
 issue. An idea must stand on its own and be worthwhile to pursue independently
 of the current state of the game.
 
-With ideas in particular, the initial explanation should show some effort. If
-you have had a shower thought that you want to explain in one line, come to IRC
-or the forums instead to build a more rounded idea with developers and other
-players first.
+Ideas that lack effort or details are tagged as such and are closed after 60 days if no more detailed and rounded idea is reached in the comments.
 
 **Example:** *Allow humans to teleport between Telenodes.*
-


### PR DESCRIPTION
I think that all feedback should be treated as personal opinions and not classified as solvable. Only documented and maybe discussed in the scope of the experience or the reporter. 

It would be nice to report problems related ideas at the same time. If a problem is not accepted as such related ideas can be automatic closed after a fixed period if they provide no additional benefit. 