### PR TITLE
Rework issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/experience.md
+++ b/.github/ISSUE_TEMPLATE/experience.md
@@ -1,10 +1,11 @@
 ---
 name: Experience
 about: Share your ingame experiences
-title: "[Experience]"
+title: ''
 labels: experience
 assignees: ''
 
 ---
 
-
+*Provide general feedback of how you experienced the game or an individual
+match. This helps us identify problems and work out solutions to them.*

--- a/.github/ISSUE_TEMPLATE/idea.md
+++ b/.github/ISSUE_TEMPLATE/idea.md
@@ -1,20 +1,13 @@
 ---
 name: Idea
 about: Single idea with optional reference to a problem
-title: "[Idea]"
+title: ''
 labels: idea
 assignees: ''
 
 ---
 Related Problem issues: 
 
-Please describe your idea without trying to solve a specific problem or the consequences for the game balance.
-This can be discussed in the following comments.
-
-
-
-
-
-
-**Disclaimer**
->Ideas without a related problem issue and lacking explanation or depth are closed after a certain time.
+*Please do not advertise your idea as solving a problem, unless that problem is
+referenced and, ideally, agreed upon. Ideas with no problem issue linked must
+be worthwhile to pursue regardless of the current state of the game!*

--- a/.github/ISSUE_TEMPLATE/meta.md
+++ b/.github/ISSUE_TEMPLATE/meta.md
@@ -1,8 +1,8 @@
 ---
 name: Meta
 about: Everything issue tracker related
-title: "[Meta]"
-labels: ''
+title: ''
+labels: meta
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/problem.md
+++ b/.github/ISSUE_TEMPLATE/problem.md
@@ -1,17 +1,13 @@
 ---
 name: Problem
-about: 'Discuss one aspect of the game that you want changed. '
-title: "[Problem]"
+about: Discuss one aspect of the game that you want changed
+title: ''
 labels: problem
 assignees: ''
 
 ---
 
-Please describe the problem as distinct as possible and try to be objective.
-
-
-
-
-
-**Disclaimer**
->All problems issues are treated as opinions until agree upon
+*Please describe the problem as distinct as possible and try to be objective.
+Refrain from advertising solution ideas, so that the problem itself can be
+analyzed and solution ideas may compete later on. Problems are treated as
+opinions until agreed upon.*


### PR DESCRIPTION
This removes the title prefix in particular but also adjusts hints.

Closes #62.